### PR TITLE
feat(disable-acc): disable acc tests in github ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,8 @@ jobs:
         with:
           go-version: '1.16'
       - run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-      - name: Setup Environment
-        run: make ci-build-setup
+      # - name: Setup Environment
+      #   run: make ci-build-setup
       - name: Build
         run: make build
   test:
@@ -32,34 +32,37 @@ jobs:
         with:
           go-version: '1.16'
       - run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-      - name: Setup Environment
-        run: make ci-build-setup
+      # - name: Setup Environment
+      #   run: make ci-build-setup
       - name: Run tests
         run: make test
-  testacc:
-    runs-on: ubuntu-latest
-    env:
-      GO111MODULE: on
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up GO 1.16.x
-        uses: actions/setup-go@v1
-        with:
-          go-version: '1.16'
-      - run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Setup Environment
-        run: make ci-build-setup
-      - name: Start bitbucket server
-        run: make bitbucket-start
-      - name: Run acceptance tests
-        run: BITBUCKET_SERVER=http://localhost:7990 BITBUCKET_USERNAME=admin BITBUCKET_PASSWORD=admin make testacc
-      - name: Stop bitbucket server
-        run: make bitbucket-stop
+  # The bitbucket server image is failing to come up in docker. For now we will
+  # rely on spinning up a container in k8s and port forwarding it to the local 
+  # machine for testing. we will revisit this job in the future
+  # testacc:
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     GO111MODULE: on
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Set up GO 1.16.x
+  #       uses: actions/setup-go@v1
+  #       with:
+  #         go-version: '1.16'
+  #     - run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v1
+  #       with:
+  #         username: ${{ secrets.DOCKERHUB_USERNAME }}
+  #         password: ${{ secrets.DOCKERHUB_TOKEN }}
+  #     - name: Setup Environment
+  #       run: make ci-build-setup
+  #     - name: Start bitbucket server
+  #       run: make bitbucket-start
+  #     - name: Run acceptance tests
+  #       run: BITBUCKET_SERVER=http://localhost:7990 BITBUCKET_USERNAME=admin BITBUCKET_PASSWORD=admin make testacc
+  #     - name: Stop bitbucket server
+  #       run: make bitbucket-stop
   fmtcheck:
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
bitbucket server 6.10.0 fails to come up in docker. To test we are able to launch it in k8s and use port forwarding to run the test suite locally.